### PR TITLE
Initial push to clean develop branch.

### DIFF
--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -197,7 +197,7 @@
         },
         {
           "command": "sfdx.force.lightning.lwc.preview",
-          "when": "false"
+          "when": "sfdx:project_opened && resource =~ /.*/lwc/[^/]+(/[^/]+\\.(html|css|js))?$/"
         },
         {
           "command": "sfdx.force.lightning.lwc.test.file.run",
@@ -346,6 +346,17 @@
           "dark": "resources/dark/stopWatching.svg"
         }
       }
-    ]
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "%force_lightning_lwc_preferences%",
+      "properties": {
+        "salesforcedx-vscode-lwc.rememberDevice": {
+          "type": "boolean",
+          "default": true,
+          "description": "%force_lightning_lwc_remember_device_description%"
+        }
+      }
+    }
   }
 }

--- a/packages/salesforcedx-vscode-lwc/package.nls.json
+++ b/packages/salesforcedx-vscode-lwc/package.nls.json
@@ -14,5 +14,7 @@
   "force_lightning_lwc_test_run_current_file_text": "SFDX: Run Current Lightning Web Component Test File",
   "force_lightning_lwc_test_debug_current_file_text": "SFDX: Debug Current Lightning Web Component Test File",
   "force_lightning_lwc_test_start_watching_text": "SFDX: Start Watching Lightning Web Component Test",
-  "force_lightning_lwc_test_stop_watching_text": "SFDX: Stop Watching Lightning Web Component Test"
+  "force_lightning_lwc_test_stop_watching_text": "SFDX: Stop Watching Lightning Web Component Test",
+  "force_lightning_lwc_preferences": "Lightning Web Components",
+  "force_lightning_lwc_remember_device_description": "Remember most recently used mobile device target."
 }

--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
@@ -6,8 +6,15 @@
  */
 
 import { componentUtil } from '@salesforce/lightning-lsp-common';
+import {
+  CliCommandExecutor,
+  Command,
+  SfdxCommandBuilder
+} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { ContinueResponse } from '@salesforce/salesforcedx-utils-vscode/out/src/types';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
+import { getGlobalStore, getWorkspaceSettings } from '../index';
 import { nls } from '../messages';
 import { DevServerService } from '../service/devServerService';
 import { DEV_SERVER_PREVIEW_ROUTE } from './commandConstants';
@@ -26,17 +33,64 @@ const {
 
 const logName = 'force_lightning_lwc_preview';
 const commandName = nls.localize('force_lightning_lwc_preview_text');
+const SfdxCommandletExecutor = sfdxCoreExports.SfdxCommandletExecutor;
+
+export enum PreviewPlatformType {
+  Desktop = 1,
+  iOS,
+  Android
+}
+
+interface PreviewQuickPickItem extends vscode.QuickPickItem {
+  id: PreviewPlatformType;
+  defaultTargetName: string;
+  platformName: string;
+}
+
+const platformInput: PreviewQuickPickItem[] = [
+  {
+    label: nls.localize('force_lightning_lwc_preview_desktop_label'),
+    detail: nls.localize('force_lightning_lwc_preview_desktop_description'),
+    alwaysShow: true,
+    picked: true,
+    id: PreviewPlatformType.Desktop,
+    platformName: '',
+    defaultTargetName: ''
+  },
+  {
+    label: nls.localize('force_lightning_lwc_preview_ios_label'),
+    detail: nls.localize('force_lightning_lwc_preview_ios_description'),
+    alwaysShow: true,
+    picked: false,
+    id: PreviewPlatformType.iOS,
+    platformName: 'iOS',
+    defaultTargetName: 'SFDXSimulator'
+  },
+  {
+    label: nls.localize('force_lightning_lwc_preview_android_label'),
+    detail: nls.localize('force_lightning_lwc_preview_android_description'),
+    alwaysShow: true,
+    picked: false,
+    id: PreviewPlatformType.Android,
+    platformName: 'Android',
+    defaultTargetName: 'SFDXEmulator'
+  }
+];
 
 export async function forceLightningLwcPreview(sourceUri: vscode.Uri) {
   const startTime = process.hrtime();
 
   if (!sourceUri) {
-    const message = nls.localize(
-      'force_lightning_lwc_preview_file_undefined',
-      sourceUri
-    );
-    showError(new Error(message), logName, commandName);
-    return;
+    if (vscode.window.activeTextEditor) {
+      sourceUri = vscode.window.activeTextEditor.document.uri;
+    } else {
+      const message = nls.localize(
+        'force_lightning_lwc_preview_file_undefined',
+        sourceUri
+      );
+      showError(new Error(message), logName, commandName);
+      return;
+    }
   }
 
   const resourcePath = sourceUri.path;
@@ -72,31 +126,103 @@ export async function forceLightningLwcPreview(sourceUri: vscode.Uri) {
     return;
   }
 
-  const fullUrl = `${DEV_SERVER_PREVIEW_ROUTE}/${componentName}`;
+  const platformSelection = await vscode.window.showQuickPick(platformInput, {
+    placeHolder: nls.localize('force_lightning_lwc_preview_platform_selection')
+  });
+  if (!platformSelection) {
+    console.log(`${logName}: No valid selection made for preview...`);
+    return;
+  }
 
-  if (DevServerService.instance.isServerHandlerRegistered()) {
-    try {
-      await openBrowser(fullUrl);
-      telemetryService.sendCommandEvent(logName, startTime);
-    } catch (e) {
-      showError(e, logName, commandName);
+  const fullUrl = `${DEV_SERVER_PREVIEW_ROUTE}/${componentName}`;
+  const desktopSelected = platformSelection.id === PreviewPlatformType.Desktop;
+  let target: string = platformSelection.defaultTargetName;
+  if (!desktopSelected) {
+    let placeholderText = nls.localize(
+      'force_lightning_lwc_preview_target_default'
+    );
+    const deviceConfig = getWorkspaceSettings().get('rememberDevice') || false;
+    const lastTarget = getRememberedDevice(platformSelection);
+
+    // Remember device setting enabled and previous device retrieved.
+    if (deviceConfig && lastTarget) {
+      placeholderText = nls.localize(
+        'force_lightning_lwc_preview_target_remembered',
+        lastTarget
+      );
+      target = lastTarget;
     }
-  } else {
-    console.log(`${logName}: server was not running, starting...`);
-    const preconditionChecker = new SfdxWorkspaceChecker();
-    const parameterGatherer = new EmptyParametersGatherer();
-    const executor = new ForceLightningLwcStartExecutor({
-      openBrowser: true,
-      fullUrl
+    const targetName = await vscode.window.showInputBox({
+      placeHolder: placeholderText
     });
 
-    const commandlet = new SfdxCommandlet(
-      preconditionChecker,
-      parameterGatherer,
-      executor
-    );
+    if (targetName === undefined) {
+      vscode.window.showInformationMessage(
+        nls.localize('force_lightning_lwc_preview_device_cancelled')
+      );
+      return;
+    }
 
-    await commandlet.run();
-    telemetryService.sendCommandEvent(logName, startTime);
+    // New target device entered
+    if (targetName !== '') {
+      updateRememberedDevice(platformSelection, targetName);
+      target = targetName;
+    }
+
+    // Start Server if not running.
+    if (!DevServerService.instance.isServerHandlerRegistered()) {
+      console.log(`${logName}: server was not running, starting...`);
+      const preconditionChecker = new SfdxWorkspaceChecker();
+      const parameterGatherer = new EmptyParametersGatherer();
+      const executor = new ForceLightningLwcStartExecutor({
+        openBrowser: desktopSelected,
+        fullUrl
+      });
+
+      const commandlet = new SfdxCommandlet(
+        preconditionChecker,
+        parameterGatherer,
+        executor
+      );
+
+      await commandlet.run();
+      telemetryService.sendCommandEvent(logName, startTime);
+    } else if (desktopSelected) {
+      try {
+        await openBrowser(fullUrl);
+        telemetryService.sendCommandEvent(logName, startTime);
+      } catch (e) {
+        showError(e, logName, commandName);
+      }
+      return;
+    }
+
+    // Launch Mobile Device
+    const mobileCancellationTokenSource = new vscode.CancellationTokenSource();
+    const mobileCancellationToken = mobileCancellationTokenSource.token;
+
+    const command = new SfdxCommandBuilder()
+      .withDescription(commandName)
+      .withArg('force:lightning:lwc:preview')
+      .withFlag('-p', platformSelection.platformName)
+      .withFlag('-t', target || platformSelection.defaultTargetName)
+      .withFlag('-f', fullUrl)
+      .build();
+
+    const mobileExecutor = new CliCommandExecutor(command, {
+      env: { SFDX_JSON_TO_STDOUT: 'true' }
+    });
+    mobileExecutor.execute(mobileCancellationToken);
   }
+}
+
+function getRememberedDevice(platform: PreviewQuickPickItem): string {
+  return getGlobalStore().get(`last${platform.platformName}Device`, '');
+}
+
+function updateRememberedDevice(
+  platform: PreviewQuickPickItem,
+  deviceName: string
+) {
+  getGlobalStore().update(`last${platform.platformName}Device`, deviceName);
 }

--- a/packages/salesforcedx-vscode-lwc/src/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/index.ts
@@ -32,6 +32,8 @@ import { DevServerService } from './service/devServerService';
 import { telemetryService } from './telemetry';
 import { activateLwcTestSupport } from './testSupport';
 
+let extensionContext: vscode.ExtensionContext;
+
 // See https://github.com/Microsoft/vscode-languageserver-node/issues/105
 export function code2ProtocolConverter(value: Uri) {
   if (/^win32/.test(process.platform)) {
@@ -48,6 +50,7 @@ function protocol2CodeConverter(value: string) {
 }
 
 export async function activate(context: ExtensionContext) {
+  extensionContext = context;
   const extensionHRStart = process.hrtime();
   console.log('Activation Mode: ' + getActivationMode());
   // Run our auto detection routine before we activate
@@ -139,7 +142,7 @@ function getActivationMode(): string {
 }
 
 function registerCommands(
-  extensionContext: vscode.ExtensionContext
+  _extensionContext: vscode.ExtensionContext
 ): vscode.Disposable {
   return vscode.Disposable.from(
     vscode.commands.registerCommand(
@@ -222,4 +225,12 @@ function startLWCLanguageServer(context: ExtensionContext) {
   // Push the disposable to the context's subscriptions so that the
   // client can be deactivated on extension deactivation
   context.subscriptions.push(client);
+}
+
+export function getGlobalStore(): vscode.Memento {
+  return extensionContext.globalState;
+}
+
+export function getWorkspaceSettings(): vscode.WorkspaceConfiguration {
+  return workspace.getConfiguration('salesforcedx-vscode-lwc');
 }

--- a/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
@@ -53,5 +53,21 @@ export const messages = {
   debug_test_title: 'Debug Test',
   run_test_task_name: 'Run Test',
   watch_test_task_name: 'Watch Test',
-  default_task_name: 'LWC Test'
+  default_task_name: 'LWC Test',
+  force_lightning_lwc_preview_platform_selection:
+    'Select the platform to preview the component',
+  force_lightning_lwc_preview_target_default:
+    'Enter the name for the target (leave blank for default)',
+  force_lightning_lwc_preview_target_remembered:
+    'Enter the name of a new target (leave blank for %s)',
+  force_lightning_lwc_preview_device_cancelled:
+    'Device target selection cancelled.',
+  force_lightning_lwc_preview_desktop_label: 'Use Desktop Browser',
+  force_lightning_lwc_preview_desktop_description:
+    'Preview component on desktop browser',
+  force_lightning_lwc_preview_ios_label: 'Use iOS Simulator',
+  force_lightning_lwc_preview_ios_description: 'Preview component on iOS',
+  force_lightning_lwc_preview_android_label: 'Use Android Emulator',
+  force_lightning_lwc_preview_android_description:
+    'Preview component on Android'
 };


### PR DESCRIPTION
Completed:
-  Launch preview from command palette if current source file in focus is an html/css/js file an lwc project.
-  Add preview on iOS and Android options.
-  Preview only starts server if it is not running and runs server if necessary no matter which target is selected.
-  Preview does not open native browser if iOS or Android is selected.
-  Preview remembers the last used iOS simulator and Android emulator (if setting is enabled).
-  Setting to disable remembering last used device. 
-  All strings in localization files and reviewed by doc.  

Todo:
-  Tests.
-  More metrics/logging?