### PR TITLE
LWC Preview for Mobile

### DIFF
--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -785,6 +785,11 @@
           "type": "boolean",
           "default": false,
           "description": "%experimental_deploy_retrieve_description%"
+        },
+        "salesforcedx-vscode-core.previewOnMobile": {
+          "type": "boolean",
+          "default": false,
+          "description": "%force_lightning_lwc_enable_mobile%"
         }
       }
     },

--- a/packages/salesforcedx-vscode-core/package.nls.json
+++ b/packages/salesforcedx-vscode-core/package.nls.json
@@ -61,5 +61,6 @@
   "force_source_retrieve_display_text": "Retrieve Source from Org",
   "force_diff_against_org": "SFDX: Diff File Against Org",
   "force_analytics_template_create_text": "SFDX: Create Sample Analytics Template",
-  "experimental_deploy_retrieve_description": "Enable performance enhancements to the deploy/retrieve experience."
+  "experimental_deploy_retrieve_description": "Enable performance enhancements to the deploy/retrieve experience.",
+  "force_lightning_lwc_enable_mobile": "Preview Lightning Web Components on Mobile. \nNote: This feature is currently in pilot release and is not generally available."
 }

--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -25,4 +25,4 @@ export const DEFAULT_USERNAME_KEY = 'defaultusername';
 export const DEFAULT_DEV_HUB_USERNAME_KEY = 'defaultdevhubusername';
 export const CONFLICT_DETECTION_ENABLED = 'detectConflictsAtSync';
 export const BETA_DEPLOY_RETRIEVE = 'experimental.deployRetrieve';
-export const LWC_MOBILE_PREVIEW_ENABLED = 'enableLwcPreviewOnMobile';
+export const LWC_MOBILE_PREVIEW_ENABLED = 'previewOnMobile';

--- a/packages/salesforcedx-vscode-core/src/constants.ts
+++ b/packages/salesforcedx-vscode-core/src/constants.ts
@@ -25,3 +25,4 @@ export const DEFAULT_USERNAME_KEY = 'defaultusername';
 export const DEFAULT_DEV_HUB_USERNAME_KEY = 'defaultdevhubusername';
 export const CONFLICT_DETECTION_ENABLED = 'detectConflictsAtSync';
 export const BETA_DEPLOY_RETRIEVE = 'experimental.deployRetrieve';
+export const LWC_MOBILE_PREVIEW_ENABLED = 'enableLwcPreviewOnMobile';

--- a/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
+++ b/packages/salesforcedx-vscode-core/src/settings/sfdxCoreSettings.ts
@@ -10,6 +10,7 @@ import {
   BETA_DEPLOY_RETRIEVE,
   CONFLICT_DETECTION_ENABLED,
   INTERNAL_DEVELOPMENT_FLAG,
+  LWC_MOBILE_PREVIEW_ENABLED,
   PUSH_OR_DEPLOY_ON_SAVE_ENABLED,
   RETRIEVE_TEST_CODE_COVERAGE,
   SFDX_CORE_CONFIGURATION_NAME,
@@ -72,6 +73,10 @@ export class SfdxCoreSettings {
 
   public getBetaDeployRetrieve(): boolean {
     return this.getConfigValue(BETA_DEPLOY_RETRIEVE, false);
+  }
+
+  public getLwcPreviewOnMobileEnabled(): boolean {
+    return this.getConfigValue(LWC_MOBILE_PREVIEW_ENABLED, false);
   }
 
   private getConfigValue<T>(key: string, defaultValue: T): T {

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -195,7 +195,7 @@
         },
         {
           "command": "sfdx.force.lightning.lwc.preview",
-          "when": "false"
+          "when": "sfdx:project_opened && resource =~ /.*/lwc/[^/]+(/[^/]+\\.(html|css|js))?$/"
         },
         {
           "command": "sfdx.force.lightning.lwc.test.file.run",
@@ -344,6 +344,30 @@
           "dark": "resources/dark/stopWatching.svg"
         }
       }
-    ]
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "%force_lightning_lwc_preferences%",
+      "properties": {
+        "salesforcedx-vscode-lwc.rememberDevice": {
+          "type": "boolean",
+          "default": true,
+          "description": "%force_lightning_lwc_remember_device_description%"
+        },
+        "salesforcedx-vscode-lwc.logLevel": {
+          "type": "string",
+          "description": "%force_lightning_lwc_mobile_log_level%",
+          "enum": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "fatal"
+          ],
+          "default": "warn"
+        }
+      }
+    }
   }
 }

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -366,11 +366,6 @@
             "fatal"
           ],
           "default": "warn"
-        },
-        "salesforcedx-vscode-lwc.enablePreviewOnMobile": {
-          "type": "boolean",
-          "default": false,
-          "description": "%force_lightning_lwc_enable_mobile%"
         }
       }
     }

--- a/packages/salesforcedx-vscode-lwc/package.json
+++ b/packages/salesforcedx-vscode-lwc/package.json
@@ -366,6 +366,11 @@
             "fatal"
           ],
           "default": "warn"
+        },
+        "salesforcedx-vscode-lwc.enablePreviewOnMobile": {
+          "type": "boolean",
+          "default": false,
+          "description": "%force_lightning_lwc_enable_mobile%"
         }
       }
     }

--- a/packages/salesforcedx-vscode-lwc/package.nls.json
+++ b/packages/salesforcedx-vscode-lwc/package.nls.json
@@ -17,5 +17,6 @@
   "force_lightning_lwc_test_stop_watching_text": "SFDX: Stop Watching Lightning Web Component Test",
   "force_lightning_lwc_preferences": "Lightning Web Components Preview",
   "force_lightning_lwc_remember_device_description": "Remember most recently used mobile device target.",
-  "force_lightning_lwc_mobile_log_level": "Log level used when calling SFDX Preview on Mobile command."
+  "force_lightning_lwc_mobile_log_level": "Log level used when calling SFDX Preview on Mobile command.",
+  "force_lightning_lwc_enable_mobile": "Warning: This feature is not publicly available."
 }

--- a/packages/salesforcedx-vscode-lwc/package.nls.json
+++ b/packages/salesforcedx-vscode-lwc/package.nls.json
@@ -15,8 +15,7 @@
   "force_lightning_lwc_test_debug_current_file_text": "SFDX: Debug Current Lightning Web Component Test File",
   "force_lightning_lwc_test_start_watching_text": "SFDX: Start Watching Lightning Web Component Test",
   "force_lightning_lwc_test_stop_watching_text": "SFDX: Stop Watching Lightning Web Component Test",
-  "force_lightning_lwc_preferences": "Lightning Web Components Preview",
+  "force_lightning_lwc_preferences": "Salesforce Lightning Web Components",
   "force_lightning_lwc_remember_device_description": "Remember most recently used mobile device target.",
-  "force_lightning_lwc_mobile_log_level": "Log level used when calling SFDX Preview on Mobile command.",
-  "force_lightning_lwc_enable_mobile": "Warning: This feature is not publicly available."
+  "force_lightning_lwc_mobile_log_level": "Log level used when calling SFDX Preview on Mobile command."
 }

--- a/packages/salesforcedx-vscode-lwc/package.nls.json
+++ b/packages/salesforcedx-vscode-lwc/package.nls.json
@@ -14,5 +14,7 @@
   "force_lightning_lwc_test_run_current_file_text": "SFDX: Run Current Lightning Web Component Test File",
   "force_lightning_lwc_test_debug_current_file_text": "SFDX: Debug Current Lightning Web Component Test File",
   "force_lightning_lwc_test_start_watching_text": "SFDX: Start Watching Lightning Web Component Test",
-  "force_lightning_lwc_test_stop_watching_text": "SFDX: Stop Watching Lightning Web Component Test"
+  "force_lightning_lwc_test_stop_watching_text": "SFDX: Stop Watching Lightning Web Component Test",
+  "force_lightning_lwc_mobile_remember_device_description": "Remember most recently used mobile device target.",
+  "force_lightning_lwc_mobile_log_level": "Log level used when calling SFDX Preview on Mobile command."
 }

--- a/packages/salesforcedx-vscode-lwc/package.nls.json
+++ b/packages/salesforcedx-vscode-lwc/package.nls.json
@@ -15,6 +15,7 @@
   "force_lightning_lwc_test_debug_current_file_text": "SFDX: Debug Current Lightning Web Component Test File",
   "force_lightning_lwc_test_start_watching_text": "SFDX: Start Watching Lightning Web Component Test",
   "force_lightning_lwc_test_stop_watching_text": "SFDX: Stop Watching Lightning Web Component Test",
-  "force_lightning_lwc_mobile_remember_device_description": "Remember most recently used mobile device target.",
+  "force_lightning_lwc_preferences": "Lightning Web Components Preview",
+  "force_lightning_lwc_remember_device_description": "Remember most recently used mobile device target.",
   "force_lightning_lwc_mobile_log_level": "Log level used when calling SFDX Preview on Mobile command."
 }

--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
@@ -6,8 +6,13 @@
  */
 
 import { componentUtil } from '@salesforce/lightning-lsp-common';
+import {
+  CliCommandExecutor,
+  SfdxCommandBuilder
+} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
+import { getGlobalStore, getWorkspaceSettings } from '../index';
 import { nls } from '../messages';
 import { DevServerService } from '../service/devServerService';
 import { DEV_SERVER_PREVIEW_ROUTE } from './commandConstants';
@@ -18,14 +23,66 @@ const sfdxCoreExports = vscode.extensions.getExtension(
   'salesforce.salesforcedx-vscode-core'
 )!.exports;
 const {
+  channelService,
+  notificationService,
   telemetryService,
   SfdxCommandlet,
   EmptyParametersGatherer,
   SfdxWorkspaceChecker
 } = sfdxCoreExports;
 
+export enum PreviewPlatformType {
+  Desktop = 1,
+  Android,
+  iOS
+}
+
+export interface PreviewQuickPickItem extends vscode.QuickPickItem {
+  label: string;
+  detail: string;
+  alwaysShow: boolean;
+  picked: boolean;
+  id: PreviewPlatformType;
+  defaultTargetName: string;
+  platformName: string;
+}
+
+export const platformInput: PreviewQuickPickItem[] = [
+  {
+    label: nls.localize('force_lightning_lwc_preview_desktop_label'),
+    detail: nls.localize('force_lightning_lwc_preview_desktop_description'),
+    alwaysShow: true,
+    picked: true,
+    id: PreviewPlatformType.Desktop,
+    platformName: '',
+    defaultTargetName: ''
+  },
+  {
+    label: nls.localize('force_lightning_lwc_android_label'),
+    detail: nls.localize('force_lightning_lwc_android_description'),
+    alwaysShow: true,
+    picked: false,
+    id: PreviewPlatformType.Android,
+    platformName: 'Android',
+    defaultTargetName: 'SFDXEmulator'
+  },
+  {
+    label: nls.localize('force_lightning_lwc_ios_label'),
+    detail: nls.localize('force_lightning_lwc_ios_description'),
+    alwaysShow: true,
+    picked: false,
+    id: PreviewPlatformType.iOS,
+    platformName: 'iOS',
+    defaultTargetName: 'SFDXSimulator'
+  }
+];
+
 const logName = 'force_lightning_lwc_preview';
 const commandName = nls.localize('force_lightning_lwc_preview_text');
+export const sfdxMobilePreviewCommand = 'force:lightning:lwc:preview';
+export const rememberDeviceKey = 'rememberDevice';
+export const logLevelKey = 'logLevel';
+export const defaultLogLevel = 'warn';
 
 export async function forceLightningLwcPreview(sourceUri: vscode.Uri) {
   const startTime = process.hrtime();
@@ -39,7 +96,7 @@ export async function forceLightningLwcPreview(sourceUri: vscode.Uri) {
     return;
   }
 
-  const resourcePath = sourceUri.path;
+  let resourcePath = sourceUri.path;
   if (!resourcePath) {
     const message = nls.localize(
       'force_lightning_lwc_preview_file_undefined',
@@ -47,6 +104,9 @@ export async function forceLightningLwcPreview(sourceUri: vscode.Uri) {
     );
     showError(new Error(message), logName, commandName);
     return;
+  } else if (resourcePath.startsWith('/c:')) {
+    // Fix path issue on Windows
+    resourcePath = resourcePath.substring(1, resourcePath.length);
   }
 
   if (!fs.existsSync(resourcePath)) {
@@ -73,8 +133,130 @@ export async function forceLightningLwcPreview(sourceUri: vscode.Uri) {
   }
 
   const fullUrl = `${DEV_SERVER_PREVIEW_ROUTE}/${componentName}`;
+  const platformSelection = await vscode.window.showQuickPick(platformInput, {
+    placeHolder: nls.localize('force_lightning_lwc_platform_selection')
+  });
+  if (!platformSelection) {
+    vscode.window.showWarningMessage(
+      nls.localize('force_lightning_lwc_cancelled')
+    );
+    return;
+  }
 
-  if (DevServerService.instance.isServerHandlerRegistered()) {
+  const desktopSelected = platformSelection.id === PreviewPlatformType.Desktop;
+  if (desktopSelected) {
+    startServer(true, fullUrl, startTime);
+    return;
+  }
+
+  let target: string = platformSelection.defaultTargetName;
+  let placeholderText =
+    platformSelection.id === PreviewPlatformType.Android
+      ? nls.localize('force_lightning_lwc_android_target_default')
+      : nls.localize('force_lightning_lwc_ios_target_default');
+  const rememberDeviceConfigured =
+    getWorkspaceSettings().get(rememberDeviceKey) || false;
+  const lastTarget = getRememberedDevice(platformSelection);
+
+  // Remember device setting enabled and previous device retrieved.
+  if (rememberDeviceConfigured && lastTarget) {
+    const message =
+      platformSelection.id === PreviewPlatformType.Android
+        ? 'force_lightning_lwc_android_target_remembered'
+        : 'force_lightning_lwc_ios_target_remembered';
+    placeholderText = nls.localize(message, lastTarget);
+    target = lastTarget;
+  }
+  const targetName = await vscode.window.showInputBox({
+    placeHolder: placeholderText
+  });
+
+  if (targetName === undefined) {
+    vscode.window.showInformationMessage(
+      platformSelection.id === PreviewPlatformType.Android
+        ? nls.localize('force_lightning_lwc_android_device_cancelled')
+        : nls.localize('force_lightning_lwc_ios_device_cancelled')
+    );
+    return;
+  }
+  startServer(false, fullUrl, startTime);
+
+  // New target device entered
+  if (targetName !== '') {
+    updateRememberedDevice(platformSelection, targetName);
+    target = targetName;
+  }
+
+  const mobileCancellationTokenSource = new vscode.CancellationTokenSource();
+  const mobileCancellationToken = mobileCancellationTokenSource.token;
+  const targetUsed = target || platformSelection.defaultTargetName;
+  const command = new SfdxCommandBuilder()
+    .withDescription(commandName)
+    .withArg(sfdxMobilePreviewCommand)
+    .withFlag('-p', platformSelection.platformName)
+    .withFlag('-t', targetUsed)
+    .withFlag('-n', componentName)
+    .withFlag(
+      '--loglevel',
+      getWorkspaceSettings().get(logLevelKey) || defaultLogLevel
+    )
+    .build();
+
+  const mobileExecutor = new CliCommandExecutor(command, {
+    env: { SFDX_JSON_TO_STDOUT: 'true' }
+  });
+  const execution = mobileExecutor.execute(mobileCancellationToken);
+  telemetryService.sendCommandEvent(logName, startTime);
+  channelService.streamCommandOutput(execution);
+  channelService.showChannelOutput();
+
+  execution.processExitSubject.subscribe(async exitCode => {
+    if (exitCode !== 0) {
+      const message =
+        platformSelection.id === PreviewPlatformType.Android
+          ? nls.localize('force_lightning_lwc_android_failure', targetUsed)
+          : nls.localize('force_lightning_lwc_ios_failure', targetUsed);
+      showError(new Error(message), logName, commandName);
+
+      // Error code 127 means the lwc on mobile sfdx plugin is not installed.
+      if (exitCode === 127) {
+        channelService.appendLine(
+          nls.localize('force_lightning_lwc_no_mobile_plugin')
+        );
+      }
+    } else if (platformSelection.id === PreviewPlatformType.iOS) {
+      notificationService.showSuccessfulExecution(execution.command.toString());
+      vscode.window.showInformationMessage(
+        nls.localize('force_lightning_lwc_ios_start', targetUsed)
+      );
+    }
+  });
+
+  // TODO: Remove this when SFDX Plugin launches Android Emulator as separate process.
+  // listen for Android Emulator finished
+  if (platformSelection.id === PreviewPlatformType.Android) {
+    execution.stdoutSubject.subscribe(async data => {
+      if (data && data.toString().includes('Opening Browser')) {
+        notificationService.showSuccessfulExecution(
+          execution.command.toString()
+        );
+        vscode.window.showInformationMessage(
+          nls.localize('force_lightning_lwc_android_start', targetUsed)
+        );
+      }
+    });
+  }
+}
+
+async function startServer(
+  desktopSelected: boolean,
+  fullUrl: string,
+  startTime: [number, number]
+) {
+  if (
+    DevServerService.instance.isServerHandlerRegistered() &&
+    desktopSelected
+  ) {
     try {
       await openBrowser(fullUrl);
       telemetryService.sendCommandEvent(logName, startTime);
@@ -86,7 +268,7 @@ export async function forceLightningLwcPreview(sourceUri: vscode.Uri) {
     const preconditionChecker = new SfdxWorkspaceChecker();
     const parameterGatherer = new EmptyParametersGatherer();
     const executor = new ForceLightningLwcStartExecutor({
-      openBrowser: true,
+      openBrowser: desktopSelected,
       fullUrl
     });
 
@@ -99,4 +281,15 @@ export async function forceLightningLwcPreview(sourceUri: vscode.Uri) {
     await commandlet.run();
     telemetryService.sendCommandEvent(logName, startTime);
   }
+}
+
+function getRememberedDevice(platform: PreviewQuickPickItem): string {
+  return getGlobalStore().get(`last${platform.platformName}Device`, '');
+}
+
+function updateRememberedDevice(
+  platform: PreviewQuickPickItem,
+  deviceName: string
+) {
+  getGlobalStore().update(`last${platform.platformName}Device`, deviceName);
 }

--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
@@ -28,7 +28,8 @@ const {
   telemetryService,
   SfdxCommandlet,
   EmptyParametersGatherer,
-  SfdxWorkspaceChecker
+  SfdxWorkspaceChecker,
+  sfdxCoreSettings
 } = sfdxCoreExports;
 
 enum PreviewPlatformType {
@@ -81,7 +82,6 @@ const logName = 'force_lightning_lwc_preview';
 const commandName = nls.localize('force_lightning_lwc_preview_text');
 const sfdxMobilePreviewCommand = 'force:lightning:lwc:preview';
 const rememberDeviceKey = 'rememberDevice';
-const mobileEnabledKey = 'enablePreviewOnMobile';
 const logLevelKey = 'logLevel';
 const defaultLogLevel = 'warn';
 const androidSuccessString = 'Launching... Opening Browser';
@@ -139,8 +139,7 @@ export async function forceLightningLwcPreview(sourceUri: vscode.Uri) {
   }
 
   const fullUrl = `${DEV_SERVER_PREVIEW_ROUTE}/${componentName}`;
-  const isMobileEnabled = getWorkspaceSettings().get(mobileEnabledKey) || false;
-  if (!isMobileEnabled) {
+  if (!sfdxCoreSettings.getLwcPreviewOnMobileEnabled()) {
     await startServer(true, fullUrl, startTime);
     return;
   }

--- a/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
+++ b/packages/salesforcedx-vscode-lwc/src/commands/forceLightningLwcPreview.ts
@@ -112,7 +112,7 @@ export async function forceLightningLwcPreview(sourceUri: vscode.Uri) {
     return;
   } else if (resourcePath.startsWith('/c:')) {
     // Fix path issue on Windows
-    resourcePath = resourcePath.substring(1, resourcePath.length);
+    resourcePath = resourcePath.substring(1);
   }
 
   if (!fs.existsSync(resourcePath)) {
@@ -139,6 +139,7 @@ export async function forceLightningLwcPreview(sourceUri: vscode.Uri) {
   }
 
   const fullUrl = `${DEV_SERVER_PREVIEW_ROUTE}/${componentName}`;
+  // Preform existing desktop behavior if mobile is not enabled.
   if (!sfdxCoreSettings.getLwcPreviewOnMobileEnabled()) {
     await startServer(true, fullUrl, startTime);
     return;

--- a/packages/salesforcedx-vscode-lwc/src/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/index.ts
@@ -142,7 +142,7 @@ function getActivationMode(): string {
 }
 
 function registerCommands(
-  extensionContext: vscode.ExtensionContext
+  _extensionContext: vscode.ExtensionContext
 ): vscode.Disposable {
   return vscode.Disposable.from(
     vscode.commands.registerCommand(

--- a/packages/salesforcedx-vscode-lwc/src/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/index.ts
@@ -32,6 +32,8 @@ import { DevServerService } from './service/devServerService';
 import { telemetryService } from './telemetry';
 import { activateLwcTestSupport } from './testSupport';
 
+let extensionContext: vscode.ExtensionContext;
+
 // See https://github.com/Microsoft/vscode-languageserver-node/issues/105
 export function code2ProtocolConverter(value: Uri) {
   if (/^win32/.test(process.platform)) {
@@ -48,6 +50,7 @@ function protocol2CodeConverter(value: string) {
 }
 
 export async function activate(context: ExtensionContext) {
+  extensionContext = context;
   const extensionHRStart = process.hrtime();
   console.log('Activation Mode: ' + getActivationMode());
   // Run our auto detection routine before we activate
@@ -222,4 +225,12 @@ function startLWCLanguageServer(context: ExtensionContext) {
   // Push the disposable to the context's subscriptions so that the
   // client can be deactivated on extension deactivation
   context.subscriptions.push(client);
+}
+
+export function getGlobalStore(): vscode.Memento {
+  return extensionContext.globalState;
+}
+
+export function getWorkspaceSettings(): vscode.WorkspaceConfiguration {
+  return workspace.getConfiguration('salesforcedx-vscode-lwc');
 }

--- a/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-lwc/src/messages/i18n.ts
@@ -35,7 +35,7 @@ export const messages = {
   force_lightning_lwc_stop_in_progress: 'Stopping local development server',
   force_lightning_lwc_preview_text: 'SFDX: Preview Component Locally',
   force_lightning_lwc_preview_file_undefined:
-    "Can't find the Lightning Web Components module. Check that %s is the correct filepath.",
+    "Can't find the Lightning Web Components module. Check that %s is the correct file path.",
   force_lightning_lwc_preview_file_nonexist:
     "Can't find the Lightning Web Components module in %s. Check that the module exists.",
   force_lightning_lwc_preview_unsupported:
@@ -55,5 +55,31 @@ export const messages = {
   debug_test_title: 'Debug Test',
   run_test_task_name: 'Run Test',
   watch_test_task_name: 'Watch Test',
-  default_task_name: 'LWC Test'
+  default_task_name: 'LWC Test',
+  force_lightning_lwc_no_mobile_plugin:
+    'To run this command, first install the @salesforce/lwc-dev-mobile plugin.',
+  force_lightning_lwc_platform_selection:
+    'Select the platform for previewing the component',
+  force_lightning_lwc_android_target_default:
+    'Enter the name for the Android emulator (leave blank for default)',
+  force_lightning_lwc_ios_target_default:
+    'Enter the name for the iOS simulator (leave blank for default)',
+  force_lightning_lwc_android_target_remembered:
+    "Enter the name for the Android emulator (leave blank for '%s')",
+  force_lightning_lwc_ios_target_remembered:
+    "Enter the name for the iOS simulator (leave blank for '%s')",
+  force_lightning_lwc_cancelled: 'Preview platform selection cancelled.',
+  force_lightning_lwc_android_device_cancelled: 'Emulator selection cancelled.',
+  force_lightning_lwc_ios_device_cancelled: 'Simulator selection cancelled.',
+  force_lightning_lwc_ios_label: 'Use iOS Simulator',
+  force_lightning_lwc_ios_description: 'Preview component on iOS',
+  force_lightning_lwc_android_label: 'Use Android Emulator',
+  force_lightning_lwc_android_description: 'Preview component on Android',
+  force_lightning_lwc_android_failure: "Failed to start Android Emulator '%s'",
+  force_lightning_lwc_ios_failure: "Failed to start iOS Simulator '%s'",
+  force_lightning_lwc_android_start: "Starting Android Emulator '%s'",
+  force_lightning_lwc_ios_start: "Starting iOS Simulator '%s'",
+  force_lightning_lwc_preview_desktop_label: 'Use Desktop Browser',
+  force_lightning_lwc_preview_desktop_description:
+    'Preview component on desktop browser'
 };

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
@@ -5,21 +5,42 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import {
+  CliCommandExecutor,
+  Command,
+  CommandBuilder,
+  CommandExecution,
+  SfdxCommandBuilder
+} from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { CliCommandExecution } from '@salesforce/salesforcedx-utils-vscode/out/src/cli';
+import { CancellationToken } from '@salesforce/salesforcedx-utils-vscode/out/src/cli/commandExecutor';
+import { expect } from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
+import { Subject } from 'rxjs/Subject';
 import * as sinon from 'sinon';
 import { SinonSandbox, SinonStub } from 'sinon';
 import * as vscode from 'vscode';
 import { DEV_SERVER_PREVIEW_ROUTE } from '../../../src/commands/commandConstants';
 import * as commandUtils from '../../../src/commands/commandUtils';
-import { forceLightningLwcPreview } from '../../../src/commands/forceLightningLwcPreview';
+import {
+  androidSuccessString,
+  defaultLogLevel,
+  forceLightningLwcPreview,
+  logLevelKey,
+  platformOptions,
+  mobileEnabledKey,
+  rememberDeviceKey,
+  sfdxMobilePreviewCommand
+} from '../../../src/commands/forceLightningLwcPreview';
 import { nls } from '../../../src/messages';
 import { DevServerService } from '../../../src/service/devServerService';
+import * as utils from '../../../src/';
 
 const sfdxCoreExports = vscode.extensions.getExtension(
   'salesforce.salesforcedx-vscode-core'
 )!.exports;
-const { SfdxCommandlet, notificationService } = sfdxCoreExports;
+const { channelService, SfdxCommandlet, notificationService } = sfdxCoreExports;
 
 describe('forceLightningLwcPreview', () => {
   let sandbox: SinonSandbox;
@@ -28,6 +49,149 @@ describe('forceLightningLwcPreview', () => {
   let existsSyncStub: sinon.SinonStub<[fs.PathLike], boolean>;
   let lstatSyncStub: sinon.SinonStub<[fs.PathLike], fs.Stats>;
   let showErrorMessageStub: sinon.SinonStub<any[], any>;
+  let showQuickPickStub: sinon.SinonStub<
+    [
+      vscode.QuickPickItem[] | Thenable<vscode.QuickPickItem[]>,
+      (vscode.QuickPickOptions | undefined)?,
+      (vscode.CancellationToken | undefined)?
+    ],
+    Thenable<vscode.QuickPickItem | undefined>
+  >;
+  let showInputBoxStub: sinon.SinonStub<
+    [
+      (vscode.InputBoxOptions | undefined)?,
+      (vscode.CancellationToken | undefined)?
+    ],
+    Thenable<string | undefined>
+  >;
+  let getConfigurationStub: sinon.SinonStub<any, vscode.WorkspaceConfiguration>;
+  let getGlobalStoreStub: sinon.SinonStub<any, vscode.Memento>;
+  let cmdWithArgSpy: sinon.SinonSpy<[string], CommandBuilder>;
+  let cmdWithFlagSpy: sinon.SinonSpy<[string, string], CommandBuilder>;
+  let mobileExecutorStub: sinon.SinonStub<
+    [(CancellationToken | undefined)?],
+    CliCommandExecution | MockExecution
+  >;
+  let mockExecution: MockExecution;
+  let showWarningMessageSpy: sinon.SinonSpy<any, any>;
+  let successInfoMessageSpy: sinon.SinonSpy<any, any>;
+  let streamCommandOutputSpy: sinon.SinonSpy<any, any>;
+  let appendLineSpy: sinon.SinonSpy<any, any>;
+
+  const validSourcePath = path.join(
+    'dev',
+    'project',
+    'force-app',
+    'main',
+    'default',
+    'lwc',
+    'foo',
+    'foo.js'
+  );
+  const validSourceUri = { path: validSourcePath } as vscode.Uri;
+  const desktopQuickPick = platformOptions[0];
+  const androidQuickPick = platformOptions[1];
+  const iOSQuickPick = platformOptions[2];
+  const rememberedAndroidDevice = 'rememberedAndroid';
+  const rememberediOSDevice = 'rememberediOS';
+  const startCommand = 'force:lightning:lwc:start';
+
+  class MockMemento implements vscode.Memento {
+    public get<T>(key: string): T | undefined {
+      switch (key) {
+        case 'lastAndroidDevice':
+          return (rememberedAndroidDevice as unknown) as T;
+        case 'lastiOSDevice':
+          return (rememberediOSDevice as unknown) as T;
+        default:
+          return undefined;
+      }
+    }
+    public update(key: string, value: any): Thenable<void> {
+      return Promise.resolve();
+    }
+  }
+
+  class MockWorkspace implements vscode.WorkspaceConfiguration {
+    // tslint:disable-next-line:member-access
+    mobileEnabled = false;
+    // tslint:disable-next-line:member-access
+    shouldRemember = false;
+    // tslint:disable-next-line:member-access
+    loglevel = defaultLogLevel;
+
+    constructor(
+      mobileEnabled: boolean,
+      shouldRemember: boolean,
+      loglevel?: string
+    ) {
+      this.mobileEnabled = mobileEnabled;
+      this.shouldRemember = shouldRemember;
+      if (loglevel !== undefined) {
+        this.loglevel = loglevel;
+      }
+    }
+
+    readonly [key: string]: any;
+    public get<T>(section: string): T | undefined;
+    public get<T>(section: string, defaultValue: T): T;
+    public get(section: any, defaultValue?: any) {
+      if (section === logLevelKey) {
+        return this.loglevel;
+      } else if (section === mobileEnabledKey) {
+        return this.mobileEnabled;
+      } else if (section === rememberDeviceKey) {
+        return this.shouldRemember;
+      } else {
+        return undefined;
+      }
+    }
+    public has(section: string): boolean {
+      return this.shouldRemember;
+    }
+    public inspect<T>(
+      section: string
+    ):
+      | {
+          key: string;
+          defaultValue?: T | undefined;
+          globalValue?: T | undefined;
+          workspaceValue?: T | undefined;
+          workspaceFolderValue?: T | undefined;
+        }
+      | undefined {
+      return undefined;
+    }
+    public update(
+      section: string,
+      value: any,
+      configurationTarget?: boolean | vscode.ConfigurationTarget | undefined
+    ): Thenable<void> {
+      return Promise.resolve();
+    }
+  }
+
+  class MockExecution implements CommandExecution {
+    public command: Command;
+    public processExitSubject: Subject<number>;
+    public processErrorSubject: Subject<Error>;
+    public stdoutSubject: Subject<string>;
+    public stderrSubject: Subject<string>;
+    private readonly childProcessPid: any;
+
+    constructor(command: Command) {
+      this.command = command;
+      this.processExitSubject = new Subject<number>();
+      this.processErrorSubject = new Subject<Error>();
+      this.stdoutSubject = new Subject<string>();
+      this.stderrSubject = new Subject<string>();
+      this.childProcessPid = '';
+    }
+
+    public killExecution(signal?: string): Promise<void> {
+      return Promise.resolve();
+    }
+  }
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -40,13 +204,40 @@ describe('forceLightningLwcPreview', () => {
       notificationService,
       'showErrorMessage'
     );
+    showQuickPickStub = sandbox.stub(vscode.window, 'showQuickPick');
+    showInputBoxStub = sandbox.stub(vscode.window, 'showInputBox');
+    getConfigurationStub = sandbox.stub(utils, 'getWorkspaceSettings');
+    getGlobalStoreStub = sandbox.stub(utils, 'getGlobalStore');
+    cmdWithArgSpy = sandbox.spy(SfdxCommandBuilder.prototype, 'withArg');
+    cmdWithFlagSpy = sandbox.spy(SfdxCommandBuilder.prototype, 'withFlag');
+    mockExecution = new MockExecution(new SfdxCommandBuilder().build());
+    mobileExecutorStub = sinon.stub(CliCommandExecutor.prototype, 'execute');
+    mobileExecutorStub.returns(mockExecution);
+    showWarningMessageSpy = sandbox.spy(vscode.window, 'showWarningMessage');
+    successInfoMessageSpy = sandbox.spy(
+      vscode.window,
+      'showInformationMessage'
+    );
+    streamCommandOutputSpy = sandbox.stub(
+      channelService,
+      'streamCommandOutput'
+    );
+    appendLineSpy = sinon.spy(channelService, 'appendLine');
   });
 
   afterEach(() => {
     sandbox.restore();
+    cmdWithArgSpy.restore();
+    cmdWithFlagSpy.restore();
+    showWarningMessageSpy.restore();
+    successInfoMessageSpy.restore();
+    mobileExecutorStub.restore();
+    streamCommandOutputSpy.restore();
+    appendLineSpy.restore();
   });
 
   it('calls openBrowser with the correct url for files', async () => {
+    getConfigurationStub.returns(new MockWorkspace(false, false));
     devServiceStub.isServerHandlerRegistered.returns(true);
 
     const testPath = path.join(
@@ -78,6 +269,7 @@ describe('forceLightningLwcPreview', () => {
   });
 
   it('calls openBrowser with the correct url for directories', async () => {
+    getConfigurationStub.returns(new MockWorkspace(false, false));
     devServiceStub.isServerHandlerRegistered.returns(true);
 
     const testPath = path.join(
@@ -108,6 +300,7 @@ describe('forceLightningLwcPreview', () => {
   });
 
   it('starts the server if it is not running yet', async () => {
+    getConfigurationStub.returns(new MockWorkspace(false, false));
     devServiceStub.isServerHandlerRegistered.returns(false);
 
     const testPath = path.join(
@@ -135,6 +328,7 @@ describe('forceLightningLwcPreview', () => {
   });
 
   it('shows an error when source path is not recognized as an lwc module file', async () => {
+    getConfigurationStub.returns(new MockWorkspace(false, false));
     devServiceStub.isServerHandlerRegistered.returns(true);
 
     const testPath = path.join('foo');
@@ -158,6 +352,7 @@ describe('forceLightningLwcPreview', () => {
   });
 
   it('shows an error when source path does not exist', async () => {
+    getConfigurationStub.returns(new MockWorkspace(false, false));
     devServiceStub.isServerHandlerRegistered.returns(true);
 
     const testPath = path.join('foo');
@@ -176,6 +371,7 @@ describe('forceLightningLwcPreview', () => {
   });
 
   it('shows an error message when open browser throws an error', async () => {
+    getConfigurationStub.returns(new MockWorkspace(false, false));
     devServiceStub.isServerHandlerRegistered.returns(true);
 
     const testPath = path.join(
@@ -206,5 +402,494 @@ describe('forceLightningLwcPreview', () => {
       showErrorMessageStub,
       sinon.match(nls.localize('command_failure', commandName))
     );
+  });
+
+  // Tests for new picklist UI that includes Desktop, Android and iOS.
+  it('calls SFDX preview with the correct url for files', async () => {
+    devServiceStub.isServerHandlerRegistered.returns(true);
+    existsSyncStub.returns(true);
+    lstatSyncStub.returns({
+      isDirectory() {
+        return false;
+      }
+    } as fs.Stats);
+
+    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getGlobalStoreStub.returns(new MockMemento());
+    showQuickPickStub.resolves(androidQuickPick);
+    showInputBoxStub.resolves('');
+    await forceLightningLwcPreview(validSourceUri);
+    mockExecution.stdoutSubject.next(androidSuccessString);
+
+    sinon.assert.calledOnce(showQuickPickStub);
+    sinon.assert.calledOnce(showInputBoxStub);
+    expect(cmdWithArgSpy.callCount).to.equal(1);
+    expect(cmdWithArgSpy.getCall(0).args[0]).equals(sfdxMobilePreviewCommand);
+    expect(cmdWithFlagSpy.callCount).to.equal(4);
+    expect(cmdWithFlagSpy.getCall(0).args).to.have.same.members([
+      '-p',
+      'Android'
+    ]);
+    expect(cmdWithFlagSpy.getCall(1).args).to.have.same.members([
+      '-t',
+      'SFDXEmulator'
+    ]);
+    expect(cmdWithFlagSpy.getCall(2).args).to.have.same.members([
+      '-n',
+      'c/foo'
+    ]);
+    expect(cmdWithFlagSpy.getCall(3).args).to.have.same.members([
+      '--loglevel',
+      'warn'
+    ]);
+    sinon.assert.calledOnce(mobileExecutorStub);
+    expect(successInfoMessageSpy.callCount).to.equal(1);
+  });
+
+  it('calls SFDX preview with the correct url for directories', async () => {
+    const testPath = path.join(
+      'dev',
+      'project',
+      'force-app',
+      'main',
+      'default',
+      'lwc',
+      'foo'
+    );
+    const sourceUri = { path: testPath } as vscode.Uri;
+
+    devServiceStub.isServerHandlerRegistered.returns(true);
+    existsSyncStub.returns(true);
+    lstatSyncStub.returns({
+      isDirectory() {
+        return true;
+      }
+    } as fs.Stats);
+
+    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getGlobalStoreStub.returns(new MockMemento());
+    showQuickPickStub.resolves(iOSQuickPick);
+    showInputBoxStub.resolves('');
+    await forceLightningLwcPreview(sourceUri);
+    mockExecution.processExitSubject.next(0);
+
+    sinon.assert.calledOnce(showQuickPickStub);
+    sinon.assert.calledOnce(showInputBoxStub);
+    expect(cmdWithArgSpy.callCount).to.equal(1);
+    expect(cmdWithArgSpy.getCall(0).args[0]).equals(sfdxMobilePreviewCommand);
+    expect(cmdWithFlagSpy.callCount).to.equal(4);
+    expect(cmdWithFlagSpy.getCall(0).args).to.have.same.members(['-p', 'iOS']);
+    expect(cmdWithFlagSpy.getCall(1).args).to.have.same.members([
+      '-t',
+      'SFDXSimulator'
+    ]);
+    expect(cmdWithFlagSpy.getCall(2).args).to.have.same.members([
+      '-n',
+      'c/foo'
+    ]);
+    expect(cmdWithFlagSpy.getCall(3).args).to.have.same.members([
+      '--loglevel',
+      'warn'
+    ]);
+    sinon.assert.calledOnce(mobileExecutorStub);
+    expect(successInfoMessageSpy.callCount).to.equal(1);
+  });
+
+  it('shows an error when source path is not recognized as an lwc module file', async () => {
+    const testPath = path.join('foo');
+    const sourceUri = { path: testPath } as vscode.Uri;
+
+    existsSyncStub.returns(true);
+    lstatSyncStub.returns({
+      isDirectory() {
+        return false;
+      }
+    } as fs.Stats);
+
+    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getGlobalStoreStub.returns(new MockMemento());
+    showQuickPickStub.resolves(androidQuickPick);
+    showInputBoxStub.resolves('test');
+    await forceLightningLwcPreview(sourceUri);
+
+    sinon.assert.calledWith(
+      showErrorMessageStub,
+      sinon.match(
+        nls.localize(`force_lightning_lwc_preview_unsupported`, 'foo')
+      )
+    );
+    sinon.assert.notCalled(mobileExecutorStub);
+    expect(successInfoMessageSpy.callCount).to.equal(0);
+  });
+
+  it('shows an error when source path does not exist', async () => {
+    const testPath = path.join('foo');
+    const sourceUri = { path: testPath } as vscode.Uri;
+
+    existsSyncStub.returns(false);
+    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getGlobalStoreStub.returns(new MockMemento());
+    showQuickPickStub.resolves(androidQuickPick);
+    showInputBoxStub.resolves(undefined);
+    await forceLightningLwcPreview(sourceUri);
+
+    sinon.assert.calledWith(
+      showErrorMessageStub,
+      sinon.match(
+        nls.localize(`force_lightning_lwc_preview_file_nonexist`, 'foo')
+      )
+    );
+    sinon.assert.notCalled(mobileExecutorStub);
+    expect(successInfoMessageSpy.callCount).to.equal(0);
+  });
+
+  it('calls SFDX preview with specified Android device name', async () => {
+    const deviceName = 'androidtestname';
+    const testPath = path.join(
+      'dev',
+      'project',
+      'force-app',
+      'main',
+      'default',
+      'lwc',
+      'foo'
+    );
+    const sourceUri = { path: testPath } as vscode.Uri;
+
+    devServiceStub.isServerHandlerRegistered.returns(true);
+    existsSyncStub.returns(true);
+    lstatSyncStub.returns({
+      isDirectory() {
+        return true;
+      }
+    } as fs.Stats);
+
+    devServiceStub.isServerHandlerRegistered.returns(true);
+    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getGlobalStoreStub.returns(new MockMemento());
+    showQuickPickStub.resolves(androidQuickPick);
+    showInputBoxStub.resolves(deviceName);
+    await forceLightningLwcPreview(sourceUri);
+    mockExecution.stdoutSubject.next(androidSuccessString);
+
+    sinon.assert.calledOnce(showQuickPickStub);
+    sinon.assert.calledOnce(showInputBoxStub);
+    expect(cmdWithFlagSpy.getCall(0).args).to.have.same.members([
+      '-p',
+      'Android'
+    ]);
+    expect(cmdWithFlagSpy.getCall(1).args).to.have.same.members([
+      '-t',
+      deviceName
+    ]);
+    sinon.assert.calledOnce(mobileExecutorStub);
+    expect(successInfoMessageSpy.callCount).to.equal(1);
+    expect(
+      successInfoMessageSpy.calledWith(
+        nls.localize('force_lightning_lwc_mobile_android_start', deviceName)
+      )
+    );
+  });
+
+  it('calls SFDX preview with specified iOS device name', async () => {
+    const deviceName = 'iostestname';
+    existsSyncStub.returns(true);
+    lstatSyncStub.returns({
+      isDirectory() {
+        return true;
+      }
+    } as fs.Stats);
+
+    devServiceStub.isServerHandlerRegistered.returns(true);
+    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getGlobalStoreStub.returns(new MockMemento());
+    showQuickPickStub.resolves(iOSQuickPick);
+    showInputBoxStub.resolves(deviceName);
+    await forceLightningLwcPreview(validSourceUri);
+    mockExecution.processExitSubject.next(0);
+
+    sinon.assert.calledOnce(showQuickPickStub);
+    sinon.assert.calledOnce(showInputBoxStub);
+    expect(cmdWithFlagSpy.getCall(0).args).to.have.same.members(['-p', 'iOS']);
+    expect(cmdWithFlagSpy.getCall(1).args).to.have.same.members([
+      '-t',
+      deviceName
+    ]);
+    sinon.assert.calledOnce(mobileExecutorStub);
+    expect(successInfoMessageSpy.callCount).to.equal(1);
+    expect(
+      successInfoMessageSpy.calledWith(
+        nls.localize('force_lightning_lwc_ios_start', deviceName)
+      )
+    );
+  });
+
+  it('calls SFDX preview with remembered Android device name', async () => {
+    devServiceStub.isServerHandlerRegistered.returns(true);
+    existsSyncStub.returns(true);
+    lstatSyncStub.returns({
+      isDirectory() {
+        return true;
+      }
+    } as fs.Stats);
+
+    getConfigurationStub.returns(new MockWorkspace(true, true));
+    getGlobalStoreStub.returns(new MockMemento());
+    showQuickPickStub.resolves(androidQuickPick);
+    showInputBoxStub.resolves('');
+    await forceLightningLwcPreview(validSourceUri);
+    mockExecution.stdoutSubject.next(androidSuccessString);
+
+    sinon.assert.calledOnce(showQuickPickStub);
+    sinon.assert.calledOnce(showInputBoxStub);
+    expect(cmdWithFlagSpy.getCall(0).args).to.have.same.members([
+      '-p',
+      'Android'
+    ]);
+    expect(cmdWithFlagSpy.getCall(1).args).to.have.same.members([
+      '-t',
+      rememberedAndroidDevice
+    ]);
+    sinon.assert.calledOnce(mobileExecutorStub);
+    expect(successInfoMessageSpy.callCount).to.equal(1);
+    expect(
+      successInfoMessageSpy.calledWith(
+        nls.localize(
+          'force_lightning_lwc_mobile_android_start',
+          rememberedAndroidDevice
+        )
+      )
+    );
+  });
+
+  it('calls SFDX preview with remembered iOS device name', async () => {
+    devServiceStub.isServerHandlerRegistered.returns(true);
+    existsSyncStub.returns(true);
+    lstatSyncStub.returns({
+      isDirectory() {
+        return true;
+      }
+    } as fs.Stats);
+
+    getConfigurationStub.returns(new MockWorkspace(true, true));
+    getGlobalStoreStub.returns(new MockMemento());
+    showQuickPickStub.resolves(iOSQuickPick);
+    showInputBoxStub.resolves('');
+    await forceLightningLwcPreview(validSourceUri);
+    mockExecution.processExitSubject.next(0);
+
+    sinon.assert.calledOnce(showQuickPickStub);
+    sinon.assert.calledOnce(showInputBoxStub);
+    expect(cmdWithFlagSpy.getCall(0).args).to.have.same.members(['-p', 'iOS']);
+    expect(cmdWithFlagSpy.getCall(1).args).to.have.same.members([
+      '-t',
+      rememberediOSDevice
+    ]);
+    sinon.assert.calledOnce(mobileExecutorStub);
+    expect(successInfoMessageSpy.callCount).to.equal(1);
+    expect(
+      successInfoMessageSpy.calledWith(
+        nls.localize(
+          'force_lightning_lwc_mobile_android_start',
+          rememberediOSDevice
+        )
+      )
+    );
+  });
+
+  it('shows warning when you cancel Android device name input', async () => {
+    existsSyncStub.returns(true);
+    lstatSyncStub.returns({
+      isDirectory() {
+        return true;
+      }
+    } as fs.Stats);
+
+    getConfigurationStub.returns(new MockWorkspace(true, true));
+    getGlobalStoreStub.returns(new MockMemento());
+    showQuickPickStub.resolves(androidQuickPick);
+    // This simulates the user hitting the escape key to cancel input.
+    showInputBoxStub.resolves(undefined);
+    await forceLightningLwcPreview(validSourceUri);
+
+    sinon.assert.calledOnce(showQuickPickStub);
+    sinon.assert.calledOnce(showInputBoxStub);
+    expect(cmdWithArgSpy.callCount).to.equal(0);
+    expect(cmdWithFlagSpy.callCount).to.equal(0);
+    sinon.assert.notCalled(mobileExecutorStub);
+    expect(
+      showWarningMessageSpy.calledWith(
+        nls.localize('force_lightning_lwc_android_device_cancelled')
+      )
+    );
+  });
+
+  it('shows warning when you cancel iOS device name input', async () => {
+    existsSyncStub.returns(true);
+    lstatSyncStub.returns({
+      isDirectory() {
+        return true;
+      }
+    } as fs.Stats);
+
+    getConfigurationStub.returns(new MockWorkspace(true, true));
+    getGlobalStoreStub.returns(new MockMemento());
+    showQuickPickStub.resolves(iOSQuickPick);
+    // This simulates the user hitting the escape key to cancel input.
+    showInputBoxStub.resolves(undefined);
+    await forceLightningLwcPreview(validSourceUri);
+
+    sinon.assert.calledOnce(showQuickPickStub);
+    sinon.assert.calledOnce(showInputBoxStub);
+    expect(cmdWithArgSpy.callCount).to.equal(0);
+    expect(cmdWithFlagSpy.callCount).to.equal(0);
+    sinon.assert.notCalled(mobileExecutorStub);
+    expect(
+      showWarningMessageSpy.calledWith(
+        nls.localize('force_lightning_lwc_ios_device_cancelled')
+      )
+    );
+  });
+
+  it('shows error in console when Android SFDX execution fails', async () => {
+    devServiceStub.isServerHandlerRegistered.returns(true);
+    existsSyncStub.returns(true);
+    lstatSyncStub.returns({
+      isDirectory() {
+        return false;
+      }
+    } as fs.Stats);
+
+    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getGlobalStoreStub.returns(new MockMemento());
+    showQuickPickStub.resolves(androidQuickPick);
+    showInputBoxStub.resolves('');
+    await forceLightningLwcPreview(validSourceUri);
+    mockExecution.processExitSubject.next(1);
+
+    sinon.assert.calledOnce(mobileExecutorStub);
+    sinon.assert.calledTwice(showErrorMessageStub);
+    sinon.assert.calledWith(
+      showErrorMessageStub,
+      sinon.match(
+        nls.localize(
+          'force_lightning_lwc_android_failure',
+          androidQuickPick.defaultTargetName
+        )
+      )
+    );
+    sinon.assert.calledOnce(streamCommandOutputSpy);
+    expect(successInfoMessageSpy.callCount).to.equal(0);
+  });
+
+  it('shows error in console when iOS SFDX execution fails', async () => {
+    devServiceStub.isServerHandlerRegistered.returns(true);
+    existsSyncStub.returns(true);
+    lstatSyncStub.returns({
+      isDirectory() {
+        return false;
+      }
+    } as fs.Stats);
+
+    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getGlobalStoreStub.returns(new MockMemento());
+    showQuickPickStub.resolves(iOSQuickPick);
+    showInputBoxStub.resolves('');
+    await forceLightningLwcPreview(validSourceUri);
+    mockExecution.processExitSubject.next(1);
+
+    sinon.assert.calledOnce(mobileExecutorStub);
+    sinon.assert.calledTwice(showErrorMessageStub);
+    sinon.assert.calledWith(
+      showErrorMessageStub,
+      sinon.match(
+        nls.localize(
+          'force_lightning_lwc_ios_failure',
+          iOSQuickPick.defaultTargetName
+        )
+      )
+    );
+    sinon.assert.calledOnce(streamCommandOutputSpy);
+    expect(successInfoMessageSpy.callCount).to.equal(0);
+  });
+
+  it('shows install message if sfdx plugin is not installed', async () => {
+    devServiceStub.isServerHandlerRegistered.returns(true);
+    existsSyncStub.returns(true);
+    lstatSyncStub.returns({
+      isDirectory() {
+        return false;
+      }
+    } as fs.Stats);
+
+    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getGlobalStoreStub.returns(new MockMemento());
+    showQuickPickStub.resolves(androidQuickPick);
+    showInputBoxStub.resolves('');
+
+    await forceLightningLwcPreview(validSourceUri);
+    mockExecution.processExitSubject.next(127);
+
+    sinon.assert.calledOnce(mobileExecutorStub);
+    sinon.assert.calledTwice(showErrorMessageStub);
+    sinon.assert.calledWith(
+      showErrorMessageStub,
+      sinon.match(
+        nls.localize(
+          'force_lightning_lwc_android_failure',
+          androidQuickPick.defaultTargetName
+        )
+      )
+    );
+    sinon.assert.calledOnce(streamCommandOutputSpy);
+    expect(successInfoMessageSpy.callCount).to.equal(0);
+
+    sinon.assert.calledTwice(appendLineSpy);
+    expect(
+      appendLineSpy.calledWith(
+        nls.localize('force_lightning_lwc_mobile_no_plugin')
+      )
+    );
+  });
+
+  it('correct log level is used when the setting is changed', async () => {
+    devServiceStub.isServerHandlerRegistered.returns(true);
+    existsSyncStub.returns(true);
+    lstatSyncStub.returns({
+      isDirectory() {
+        return false;
+      }
+    } as fs.Stats);
+
+    getConfigurationStub.returns(new MockWorkspace(true, false, 'debug'));
+    getGlobalStoreStub.returns(new MockMemento());
+    showQuickPickStub.resolves(androidQuickPick);
+    showInputBoxStub.resolves('');
+    await forceLightningLwcPreview(validSourceUri);
+    mockExecution.stdoutSubject.next(androidSuccessString);
+
+    sinon.assert.calledOnce(showQuickPickStub);
+    sinon.assert.calledOnce(showInputBoxStub);
+    expect(cmdWithArgSpy.callCount).to.equal(1);
+    expect(cmdWithArgSpy.getCall(0).args[0]).equals(sfdxMobilePreviewCommand);
+    expect(cmdWithFlagSpy.callCount).to.equal(4);
+    expect(cmdWithFlagSpy.getCall(0).args).to.have.same.members([
+      '-p',
+      'Android'
+    ]);
+    expect(cmdWithFlagSpy.getCall(1).args).to.have.same.members([
+      '-t',
+      'SFDXEmulator'
+    ]);
+    expect(cmdWithFlagSpy.getCall(2).args).to.have.same.members([
+      '-n',
+      'c/foo'
+    ]);
+    expect(cmdWithFlagSpy.getCall(3).args).to.have.same.members([
+      '--loglevel',
+      'debug'
+    ]);
+    sinon.assert.calledOnce(mobileExecutorStub);
+    expect(successInfoMessageSpy.callCount).to.equal(1);
   });
 });

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
@@ -34,7 +34,12 @@ import * as utils from '../../../src/';
 const sfdxCoreExports = vscode.extensions.getExtension(
   'salesforce.salesforcedx-vscode-core'
 )!.exports;
-const { channelService, SfdxCommandlet, notificationService } = sfdxCoreExports;
+const {
+  channelService,
+  SfdxCommandlet,
+  sfdxCoreSettings,
+  notificationService
+} = sfdxCoreExports;
 const sfdxMobilePreviewCommand = 'force:lightning:lwc:preview';
 const rememberDeviceKey = 'rememberDevice';
 const mobileEnabledKey = 'enablePreviewOnMobile';
@@ -77,6 +82,7 @@ describe('forceLightningLwcPreview', () => {
   let successInfoMessageSpy: sinon.SinonSpy<any, any>;
   let streamCommandOutputSpy: sinon.SinonSpy<any, any>;
   let appendLineSpy: sinon.SinonSpy<any, any>;
+  let mobileEnabledStub: sinon.SinonStub<any, any>;
 
   const validSourcePath = path.join(
     'dev',
@@ -104,7 +110,6 @@ describe('forceLightningLwcPreview', () => {
   const iOSQuickPick = platformOptions[2];
   const rememberedAndroidDevice = 'rememberedAndroid';
   const rememberediOSDevice = 'rememberediOS';
-  const startCommand = 'force:lightning:lwc:start';
 
   class MockMemento implements vscode.Memento {
     public get<T>(key: string): T | undefined {
@@ -124,18 +129,11 @@ describe('forceLightningLwcPreview', () => {
 
   class MockWorkspace implements vscode.WorkspaceConfiguration {
     // tslint:disable-next-line:member-access
-    mobileEnabled = false;
-    // tslint:disable-next-line:member-access
     shouldRemember = false;
     // tslint:disable-next-line:member-access
     loglevel = defaultLogLevel;
 
-    constructor(
-      mobileEnabled: boolean,
-      shouldRemember: boolean,
-      loglevel?: string
-    ) {
-      this.mobileEnabled = mobileEnabled;
+    constructor(shouldRemember: boolean, loglevel?: string) {
       this.shouldRemember = shouldRemember;
       if (loglevel !== undefined) {
         this.loglevel = loglevel;
@@ -148,8 +146,6 @@ describe('forceLightningLwcPreview', () => {
     public get(section: any, defaultValue?: any) {
       if (section === logLevelKey) {
         return this.loglevel;
-      } else if (section === mobileEnabledKey) {
-        return this.mobileEnabled;
       } else if (section === rememberDeviceKey) {
         return this.shouldRemember;
       } else {
@@ -233,6 +229,10 @@ describe('forceLightningLwcPreview', () => {
       'streamCommandOutput'
     );
     appendLineSpy = sinon.spy(channelService, 'appendLine');
+    mobileEnabledStub = sinon.stub(
+      sfdxCoreSettings,
+      'getLwcPreviewOnMobileEnabled'
+    );
   });
 
   afterEach(() => {
@@ -244,11 +244,12 @@ describe('forceLightningLwcPreview', () => {
     mobileExecutorStub.restore();
     streamCommandOutputSpy.restore();
     appendLineSpy.restore();
+    mobileEnabledStub.restore();
   });
 
   it('calls openBrowser with the correct url for files', async () => {
     // Returns false for enabling mobile, false for remembered device settings.
-    getConfigurationStub.returns(new MockWorkspace(false, false));
+    getConfigurationStub.returns(new MockWorkspace(false));
     devServiceStub.isServerHandlerRegistered.returns(true);
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
@@ -267,7 +268,7 @@ describe('forceLightningLwcPreview', () => {
   });
 
   it('calls openBrowser with the correct url for directories', async () => {
-    getConfigurationStub.returns(new MockWorkspace(false, false));
+    getConfigurationStub.returns(new MockWorkspace(false));
     devServiceStub.isServerHandlerRegistered.returns(true);
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
@@ -286,7 +287,7 @@ describe('forceLightningLwcPreview', () => {
   });
 
   it('starts the server if it is not running yet', async () => {
-    getConfigurationStub.returns(new MockWorkspace(false, false));
+    getConfigurationStub.returns(new MockWorkspace(false));
     devServiceStub.isServerHandlerRegistered.returns(false);
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
@@ -302,7 +303,7 @@ describe('forceLightningLwcPreview', () => {
   });
 
   it('shows an error when source path is not recognized as an lwc module file', async () => {
-    getConfigurationStub.returns(new MockWorkspace(false, false));
+    getConfigurationStub.returns(new MockWorkspace(false));
     devServiceStub.isServerHandlerRegistered.returns(true);
 
     const testPath = path.join('foo');
@@ -326,7 +327,7 @@ describe('forceLightningLwcPreview', () => {
   });
 
   it('shows an error when source path does not exist', async () => {
-    getConfigurationStub.returns(new MockWorkspace(false, false));
+    getConfigurationStub.returns(new MockWorkspace(false));
     devServiceStub.isServerHandlerRegistered.returns(true);
 
     const testPath = path.join('foo');
@@ -345,7 +346,7 @@ describe('forceLightningLwcPreview', () => {
   });
 
   it('shows an error message when open browser throws an error', async () => {
-    getConfigurationStub.returns(new MockWorkspace(false, false));
+    getConfigurationStub.returns(new MockWorkspace(false));
     devServiceStub.isServerHandlerRegistered.returns(true);
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
@@ -370,8 +371,8 @@ describe('forceLightningLwcPreview', () => {
   // TODO: Remove tests above this line when enable mobile configuration setting is removed.
   it('calls openBrowser from quick pick with the correct url for files', async () => {
     devServiceStub.isServerHandlerRegistered.returns(true);
-    // Returns true for enabling mobile, false for remembered device settings.
-    getConfigurationStub.returns(new MockWorkspace(true, false));
+    mobileEnabledStub.returns(true);
+    getConfigurationStub.returns(new MockWorkspace(false));
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
@@ -390,7 +391,8 @@ describe('forceLightningLwcPreview', () => {
 
   it('calls openBrowser from quick pick with the correct url for directories', async () => {
     devServiceStub.isServerHandlerRegistered.returns(true);
-    getConfigurationStub.returns(new MockWorkspace(true, false));
+    mobileEnabledStub.returns(true);
+    getConfigurationStub.returns(new MockWorkspace(false));
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
@@ -409,12 +411,9 @@ describe('forceLightningLwcPreview', () => {
 
   it('starts the server if it is not running when desktop selected', async () => {
     devServiceStub.isServerHandlerRegistered.returns(false);
-    getConfigurationStub.returns(new MockWorkspace(true, false));
-
-    const testPath = path.join('force-app', 'main', 'default', 'lwc', 'hello');
-    const sourceUri = { path: testPath } as vscode.Uri;
-
-    getConfigurationStub.returns(new MockWorkspace(true, false));
+    mobileEnabledStub.returns(true);
+    getConfigurationStub.returns(new MockWorkspace(false));
+    getConfigurationStub.returns(new MockWorkspace(false));
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
@@ -429,17 +428,15 @@ describe('forceLightningLwcPreview', () => {
   });
 
   it('starts the server if it is not running when Android selected', async () => {
-    const testPath = path.join('force-app', 'main', 'default', 'lwc', 'hello');
-    const sourceUri = { path: testPath } as vscode.Uri;
-
     devServiceStub.isServerHandlerRegistered.returns(false);
+    mobileEnabledStub.returns(true);
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
         return false;
       }
     } as fs.Stats);
-    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getConfigurationStub.returns(new MockWorkspace(false));
     getGlobalStoreStub.returns(new MockMemento());
     showQuickPickStub.resolves(androidQuickPick);
     showInputBoxStub.resolves('');
@@ -474,17 +471,15 @@ describe('forceLightningLwcPreview', () => {
   });
 
   it('starts the server if it is not running when iOS selected', async () => {
-    const testPath = path.join('force-app', 'main', 'default', 'lwc', 'hello');
-    const sourceUri = { path: testPath } as vscode.Uri;
-
     devServiceStub.isServerHandlerRegistered.returns(false);
+    mobileEnabledStub.returns(true);
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
         return false;
       }
     } as fs.Stats);
-    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getConfigurationStub.returns(new MockWorkspace(false));
     getGlobalStoreStub.returns(new MockMemento());
     showQuickPickStub.resolves(iOSQuickPick);
     showInputBoxStub.resolves('');
@@ -516,12 +511,12 @@ describe('forceLightningLwcPreview', () => {
   });
 
   it('shows an error when source path is not recognized as an lwc module file', async () => {
-    devServiceStub.isServerHandlerRegistered.returns(true);
-    getConfigurationStub.returns(new MockWorkspace(true, false));
-
     const testPath = path.join('foo');
     const sourceUri = { path: testPath } as vscode.Uri;
 
+    devServiceStub.isServerHandlerRegistered.returns(true);
+    mobileEnabledStub.returns(true);
+    getConfigurationStub.returns(new MockWorkspace(false));
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
@@ -541,13 +536,14 @@ describe('forceLightningLwcPreview', () => {
   });
 
   it('shows an error when source path does not exist', async () => {
-    devServiceStub.isServerHandlerRegistered.returns(true);
-    getConfigurationStub.returns(new MockWorkspace(true, false));
     const testPath = path.join('foo');
     const sourceUri = { path: testPath } as vscode.Uri;
+
+    devServiceStub.isServerHandlerRegistered.returns(true);
+    mobileEnabledStub.returns(true);
+    getConfigurationStub.returns(new MockWorkspace(false));
     existsSyncStub.returns(false);
     showQuickPickStub.resolves(desktopQuickPick);
-
     await forceLightningLwcPreview(sourceUri);
 
     sinon.assert.calledWith(
@@ -560,7 +556,8 @@ describe('forceLightningLwcPreview', () => {
 
   it('shows an error message when open browser throws an error', async () => {
     devServiceStub.isServerHandlerRegistered.returns(true);
-    getConfigurationStub.returns(new MockWorkspace(true, false));
+    mobileEnabledStub.returns(true);
+    getConfigurationStub.returns(new MockWorkspace(false));
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
@@ -570,7 +567,6 @@ describe('forceLightningLwcPreview', () => {
 
     showQuickPickStub.resolves(desktopQuickPick);
     openBrowserStub.throws('test error');
-
     await forceLightningLwcPreview(validDirectoryUri);
 
     const commandName = nls.localize(`force_lightning_lwc_preview_text`);
@@ -583,6 +579,7 @@ describe('forceLightningLwcPreview', () => {
 
   it('calls SFDX preview with the correct url for files', async () => {
     devServiceStub.isServerHandlerRegistered.returns(true);
+    mobileEnabledStub.returns(true);
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
@@ -590,7 +587,7 @@ describe('forceLightningLwcPreview', () => {
       }
     } as fs.Stats);
 
-    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getConfigurationStub.returns(new MockWorkspace(false));
     getGlobalStoreStub.returns(new MockMemento());
     showQuickPickStub.resolves(androidQuickPick);
     showInputBoxStub.resolves('');
@@ -624,6 +621,7 @@ describe('forceLightningLwcPreview', () => {
 
   it('calls SFDX preview with the correct url for directories', async () => {
     devServiceStub.isServerHandlerRegistered.returns(true);
+    mobileEnabledStub.returns(true);
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
@@ -631,7 +629,7 @@ describe('forceLightningLwcPreview', () => {
       }
     } as fs.Stats);
 
-    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getConfigurationStub.returns(new MockWorkspace(false));
     getGlobalStoreStub.returns(new MockMemento());
     showQuickPickStub.resolves(iOSQuickPick);
     showInputBoxStub.resolves('');
@@ -663,7 +661,6 @@ describe('forceLightningLwcPreview', () => {
   it('shows an error when source path is not recognized as an lwc module file', async () => {
     const testPath = path.join('foo');
     const sourceUri = { path: testPath } as vscode.Uri;
-
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
@@ -671,7 +668,8 @@ describe('forceLightningLwcPreview', () => {
       }
     } as fs.Stats);
 
-    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getConfigurationStub.returns(new MockWorkspace(false));
+    mobileEnabledStub.returns(true);
     getGlobalStoreStub.returns(new MockMemento());
     showQuickPickStub.resolves(androidQuickPick);
     showInputBoxStub.resolves('test');
@@ -692,7 +690,8 @@ describe('forceLightningLwcPreview', () => {
     const sourceUri = { path: testPath } as vscode.Uri;
 
     existsSyncStub.returns(false);
-    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getConfigurationStub.returns(new MockWorkspace(false));
+    mobileEnabledStub.returns(true);
     getGlobalStoreStub.returns(new MockMemento());
     showQuickPickStub.resolves(androidQuickPick);
     showInputBoxStub.resolves(undefined);
@@ -711,6 +710,7 @@ describe('forceLightningLwcPreview', () => {
   it('calls SFDX preview with specified Android device name', async () => {
     const deviceName = 'androidtestname';
     devServiceStub.isServerHandlerRegistered.returns(true);
+    mobileEnabledStub.returns(true);
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
@@ -718,7 +718,7 @@ describe('forceLightningLwcPreview', () => {
       }
     } as fs.Stats);
 
-    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getConfigurationStub.returns(new MockWorkspace(false));
     getGlobalStoreStub.returns(new MockMemento());
     showQuickPickStub.resolves(androidQuickPick);
     showInputBoxStub.resolves(deviceName);
@@ -754,7 +754,8 @@ describe('forceLightningLwcPreview', () => {
     } as fs.Stats);
 
     devServiceStub.isServerHandlerRegistered.returns(true);
-    getConfigurationStub.returns(new MockWorkspace(true, false));
+    mobileEnabledStub.returns(true);
+    getConfigurationStub.returns(new MockWorkspace(false));
     getGlobalStoreStub.returns(new MockMemento());
     showQuickPickStub.resolves(iOSQuickPick);
     showInputBoxStub.resolves(deviceName);
@@ -779,6 +780,7 @@ describe('forceLightningLwcPreview', () => {
 
   it('calls SFDX preview with remembered Android device name', async () => {
     devServiceStub.isServerHandlerRegistered.returns(true);
+    mobileEnabledStub.returns(true);
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
@@ -786,7 +788,7 @@ describe('forceLightningLwcPreview', () => {
       }
     } as fs.Stats);
 
-    getConfigurationStub.returns(new MockWorkspace(true, true));
+    getConfigurationStub.returns(new MockWorkspace(true));
     getGlobalStoreStub.returns(new MockMemento());
     showQuickPickStub.resolves(androidQuickPick);
     showInputBoxStub.resolves('');
@@ -817,6 +819,7 @@ describe('forceLightningLwcPreview', () => {
 
   it('calls SFDX preview with remembered iOS device name', async () => {
     devServiceStub.isServerHandlerRegistered.returns(true);
+    mobileEnabledStub.returns(true);
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
@@ -824,7 +827,7 @@ describe('forceLightningLwcPreview', () => {
       }
     } as fs.Stats);
 
-    getConfigurationStub.returns(new MockWorkspace(true, true));
+    getConfigurationStub.returns(new MockWorkspace(true));
     getGlobalStoreStub.returns(new MockMemento());
     showQuickPickStub.resolves(iOSQuickPick);
     showInputBoxStub.resolves('');
@@ -848,6 +851,7 @@ describe('forceLightningLwcPreview', () => {
   });
 
   it('shows warning when you cancel Android device name input', async () => {
+    mobileEnabledStub.returns(true);
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
@@ -855,7 +859,7 @@ describe('forceLightningLwcPreview', () => {
       }
     } as fs.Stats);
 
-    getConfigurationStub.returns(new MockWorkspace(true, true));
+    getConfigurationStub.returns(new MockWorkspace(true));
     getGlobalStoreStub.returns(new MockMemento());
     showQuickPickStub.resolves(androidQuickPick);
     // This simulates the user hitting the escape key to cancel input.
@@ -875,6 +879,7 @@ describe('forceLightningLwcPreview', () => {
   });
 
   it('shows warning when you cancel iOS device name input', async () => {
+    mobileEnabledStub.returns(true);
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
@@ -882,7 +887,7 @@ describe('forceLightningLwcPreview', () => {
       }
     } as fs.Stats);
 
-    getConfigurationStub.returns(new MockWorkspace(true, true));
+    getConfigurationStub.returns(new MockWorkspace(true));
     getGlobalStoreStub.returns(new MockMemento());
     showQuickPickStub.resolves(iOSQuickPick);
     // This simulates the user hitting the escape key to cancel input.
@@ -903,6 +908,7 @@ describe('forceLightningLwcPreview', () => {
 
   it('shows error in console when Android SFDX execution fails', async () => {
     devServiceStub.isServerHandlerRegistered.returns(true);
+    mobileEnabledStub.returns(true);
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
@@ -910,7 +916,7 @@ describe('forceLightningLwcPreview', () => {
       }
     } as fs.Stats);
 
-    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getConfigurationStub.returns(new MockWorkspace(false));
     getGlobalStoreStub.returns(new MockMemento());
     showQuickPickStub.resolves(androidQuickPick);
     showInputBoxStub.resolves('');
@@ -934,6 +940,7 @@ describe('forceLightningLwcPreview', () => {
 
   it('shows error in console when iOS SFDX execution fails', async () => {
     devServiceStub.isServerHandlerRegistered.returns(true);
+    mobileEnabledStub.returns(true);
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
@@ -941,7 +948,7 @@ describe('forceLightningLwcPreview', () => {
       }
     } as fs.Stats);
 
-    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getConfigurationStub.returns(new MockWorkspace(false));
     getGlobalStoreStub.returns(new MockMemento());
     showQuickPickStub.resolves(iOSQuickPick);
     showInputBoxStub.resolves('');
@@ -965,6 +972,7 @@ describe('forceLightningLwcPreview', () => {
 
   it('shows install message if sfdx plugin is not installed', async () => {
     devServiceStub.isServerHandlerRegistered.returns(true);
+    mobileEnabledStub.returns(true);
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
@@ -972,7 +980,7 @@ describe('forceLightningLwcPreview', () => {
       }
     } as fs.Stats);
 
-    getConfigurationStub.returns(new MockWorkspace(true, false));
+    getConfigurationStub.returns(new MockWorkspace(false));
     getGlobalStoreStub.returns(new MockMemento());
     showQuickPickStub.resolves(androidQuickPick);
     showInputBoxStub.resolves('');
@@ -1004,6 +1012,7 @@ describe('forceLightningLwcPreview', () => {
 
   it('correct log level is used when the setting is changed', async () => {
     devServiceStub.isServerHandlerRegistered.returns(true);
+    mobileEnabledStub.returns(true);
     existsSyncStub.returns(true);
     lstatSyncStub.returns({
       isDirectory() {
@@ -1011,7 +1020,7 @@ describe('forceLightningLwcPreview', () => {
       }
     } as fs.Stats);
 
-    getConfigurationStub.returns(new MockWorkspace(true, false, 'debug'));
+    getConfigurationStub.returns(new MockWorkspace(false, 'debug'));
     getGlobalStoreStub.returns(new MockMemento());
     showQuickPickStub.resolves(androidQuickPick);
     showInputBoxStub.resolves('');

--- a/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/vscode-integration/commands/forceLightningLwcPreview.test.ts
@@ -42,7 +42,6 @@ const {
 } = sfdxCoreExports;
 const sfdxMobilePreviewCommand = 'force:lightning:lwc:preview';
 const rememberDeviceKey = 'rememberDevice';
-const mobileEnabledKey = 'enablePreviewOnMobile';
 const logLevelKey = 'logLevel';
 const defaultLogLevel = 'warn';
 const androidSuccessString = 'Launching... Opening Browser';


### PR DESCRIPTION
Completed:
- [x] Feature Flag - settings configuration to toggle Mobile Features.  Default off.
- [x] LWC Server Management
- [x] Remembers last used simulator/emulator (settings toggle to disable).
- [x] Success and failure notifications for iOS and Android.
- [x] Preview command can be launched from command palette.
- [x] Windows Support.
- [x] Configurable log level.
- [x] Updated existing tests.
- [x] Added mobile specific tests.
- [x] Add updated version of existing desktop tests for new UI. 